### PR TITLE
Develop

### DIFF
--- a/IncognitoResurrected.lua
+++ b/IncognitoResurrected.lua
@@ -1,5 +1,10 @@
 ------------------------
----      Module      ---
+---		Version      ---
+------------------------
+// Version: 1.1.1
+
+------------------------
+---		Module       ---
 ------------------------
 
 IncognitoResurrected  = LibStub("AceAddon-3.0"):NewAddon(	"IncognitoResurrected",

--- a/IncognitoResurrected.lua
+++ b/IncognitoResurrected.lua
@@ -2,16 +2,13 @@
 ---		Version      ---
 ---		 1.1.1       ---
 ------------------------
-
-
 ------------------------
 ---		Module       ---
 ------------------------
-
-IncognitoResurrected  = LibStub("AceAddon-3.0"):NewAddon(	"IncognitoResurrected",
-												"AceConsole-3.0",
-												"AceEvent-3.0",
-												"AceHook-3.0");
+IncognitoResurrected = LibStub("AceAddon-3.0"):NewAddon("IncognitoResurrected",
+                                                        "AceConsole-3.0",
+                                                        "AceEvent-3.0",
+                                                        "AceHook-3.0");
 
 ----------------------------
 --      Localization      --
@@ -20,159 +17,160 @@ IncognitoResurrected  = LibStub("AceAddon-3.0"):NewAddon(	"IncognitoResurrected"
 local L = LibStub("AceLocale-3.0"):GetLocale("IncognitoResurrected", true)
 
 local Options = {
-	name = "Incognito Resurrected",
-	type = "group",
-	args = {
-		generalSettings = {
-		name = "General Settings",
-		type = "group",
-		inline = true,
-		order = 0,
-		get = function(item) return IncognitoResurrected.db.profile[item[#item]] end,
-		set = function(item, value) IncognitoResurrected.db.profile[item[#item]] = value end,
-		args = {
-				name = {
-				order = 1,
-				type = "input",
-				name = L["name"],
-				desc = L["name_desc"],
-			},
-				enable = {	
-				order = 2,
-				type = "toggle",
-				name = L["enable"],
-				desc = L["enable_desc"],
-				width = "full",
-			},	
-				hideOnMatchingCharName = {
-				order = 3,
-				type = "toggle",
-				name = L["hideOnMatchingCharName"],
-				desc = L["hideOnMatchingCharName_desc"],
-				width = "full",
-			},
-		},
-	},
-		generalOptions = {
-		name = "Options",
-		type = "group",
-		inline = true,
-		order = 1,
-		get = function(item) return IncognitoResurrected.db.profile[item[#item]] end,
-		set = function(item, value) IncognitoResurrected.db.profile[item[#item]] = value end,
-		args = {
-			guild = {
-				order = 1,
-				type = "toggle",
-				width = "full",
-				name = L["guild"],
-				desc = L["guild_desc"],
-				},
-			guildinfo = {
-				order = 2,
-				type = "description",
-				name = "|cFFFFA500" .. L["guildinfo"],
-				},
-			party = {
-				order = 3,
-				type = "toggle",
-				width = "full",
-				name = L["party"],
-				desc = L["party_desc"],	
-				},
-			raid = {
-				order = 4,
-				type = "toggle",
-				width = "full",
-				name = L["raid"],
-				desc = L["raid_desc"],
-				},
-			instance_chat = {
-				order = 5,
-				type = "toggle",
-				width = "full",
-				name = L["instance_chat"],
-				desc = L["instance_chat_desc"],				
-				},
-			world_chat = {
-				order = 6,
-				type = "toggle",
-				width = "full",
-				name = L["world_chat"],
-				desc = L["world_chat_desc"]
-			}
-			channel = {
-				order = 7,
-				type = "input",
-				name = L["channel"],
-				desc = L["channel_desc"],
-				},
-			channelinfo = {
-				order = 8, 
-				type = "description",
-				name = "|cFFFFA500" .. L["channel_info_text"],
-				
-				},
-			debug = {
-				order = 9,
-				type = "toggle",
-				width = "full",
-				name = L["debug"],
-				desc = L["debug_desc"],
-				},				
-			},
-		},
-	},
+    name = "Incognito Resurrected",
+    type = "group",
+    args = {
+        generalSettings = {
+            name = "General Settings",
+            type = "group",
+            inline = true,
+            order = 0,
+            get = function(item)
+                return IncognitoResurrected.db.profile[item[#item]]
+            end,
+            set = function(item, value)
+                IncognitoResurrected.db.profile[item[#item]] = value
+            end,
+            args = {
+                name = {
+                    order = 1,
+                    type = "input",
+                    name = L["name"],
+                    desc = L["name_desc"]
+                },
+                enable = {
+                    order = 2,
+                    type = "toggle",
+                    name = L["enable"],
+                    desc = L["enable_desc"],
+                    width = "full"
+                },
+                hideOnMatchingCharName = {
+                    order = 3,
+                    type = "toggle",
+                    name = L["hideOnMatchingCharName"],
+                    desc = L["hideOnMatchingCharName_desc"],
+                    width = "full"
+                }
+            }
+        },
+        generalOptions = {
+            name = "Options",
+            type = "group",
+            inline = true,
+            order = 1,
+            get = function(item)
+                return IncognitoResurrected.db.profile[item[#item]]
+            end,
+            set = function(item, value)
+                IncognitoResurrected.db.profile[item[#item]] = value
+            end,
+            args = {
+                guild = {
+                    order = 1,
+                    type = "toggle",
+                    width = "full",
+                    name = L["guild"],
+                    desc = L["guild_desc"]
+                },
+                guildinfo = {
+                    order = 2,
+                    type = "description",
+                    name = "|cFFFFA500" .. L["guildinfo"]
+                },
+                party = {
+                    order = 3,
+                    type = "toggle",
+                    width = "full",
+                    name = L["party"],
+                    desc = L["party_desc"]
+                },
+                raid = {
+                    order = 4,
+                    type = "toggle",
+                    width = "full",
+                    name = L["raid"],
+                    desc = L["raid_desc"]
+                },
+                instance_chat = {
+                    order = 5,
+                    type = "toggle",
+                    width = "full",
+                    name = L["instance_chat"],
+                    desc = L["instance_chat_desc"]
+                },
+                world_chat = {
+                    order = 6,
+                    type = "toggle",
+                    width = "full",
+                    name = L["world_chat"],
+                    desc = L["world_chat_desc"]
+                },
+                world_chat_info = {
+                    order = 7,
+                    type = "description",
+                    name = "|cFFFFA500" .. L["world_chat_info_desc"]
+                },
+                channel = {
+                    order = 8,
+                    type = "input",
+                    name = L["channel"],
+                    desc = L["channel_desc"]
+                },
+                channelinfo = {
+                    order = 9,
+                    type = "description",
+                    name = "|cFFFFA500" .. L["channel_info_text"]
+
+                },
+                debug = {
+                    order = 10,
+                    type = "toggle",
+                    width = "full",
+                    name = L["debug"],
+                    desc = L["debug_desc"]
+                }
+            }
+        }
+    }
 }
 
 local Defaults = {
-	profile = {
-		enable = true,
-		guild = true,
-		party = false,
-		raid = false,
-		instance_chat = false,
-		debug = false,
-		channel = nil,
-		hideOnMatchingCharName = true,
-	},
+    profile = {
+        enable = true,
+        guild = true,
+        party = false,
+        raid = false,
+        instance_chat = false,
+        debug = false,
+        channel = nil,
+        hideOnMatchingCharName = true
+    }
 }
-
 
 local SlashOptions = {
-	type = "group",
-	handler = IncognitoResurrected,
-	get = function(item) return IncognitoResurrected.db.profile[item[#item]] end,
-	set = function(item, value) IncognitoResurrected.db.profile[item[#item]] = value end,
-	args = {
-		enable = {
-			name = L["enable"],
-			desc = L["enable_desc"],
-			type = "toggle",
-		},
-		name = {
-			name = L["name"],
-			desc = L["name_desc"],
-			type = "input",
-		},
-	 	config = {
-			name = L["config"],
-			desc = L["config_desc"],
-			guiHidden = true,
-			type = "execute",
-			func = function()
-				InterfaceOptionsFrame_OpenToCategory(IncognitoResurrected)
-			end,
-		},
-	},
+    type = "group",
+    handler = IncognitoResurrected,
+    get = function(item) return IncognitoResurrected.db.profile[item[#item]] end,
+    set = function(item, value)
+        IncognitoResurrected.db.profile[item[#item]] = value
+    end,
+    args = {
+        enable = {name = L["enable"], desc = L["enable_desc"], type = "toggle"},
+        name = {name = L["name"], desc = L["name_desc"], type = "input"},
+        config = {
+            name = L["config"],
+            desc = L["config_desc"],
+            guiHidden = true,
+            type = "execute",
+            func = function()
+                InterfaceOptionsFrame_OpenToCategory(IncognitoResurrected)
+            end
+        }
+    }
 }
 
-
-local SlashCmds = {
-  "inc",
-  "incognito",
-  "IncognitoResurrected",
-};
+local SlashCmds = {"inc", "incognito", "IncognitoResurrected"};
 
 local character_name
 
@@ -181,32 +179,34 @@ local character_name
 ----------------------
 
 function IncognitoResurrected:OnInitialize()
-	-- Load our database.
-	self.db = LibStub("AceDB-3.0"):New("IncognitoResurrectedDB", Defaults, true)
+    -- Load our database.
+    self.db = LibStub("AceDB-3.0"):New("IncognitoResurrectedDB", Defaults, true)
 
-	-- Set up our config options.
-	local profiles = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db)
-  
-	local config = LibStub("AceConfig-3.0")
-	config:RegisterOptionsTable("IncognitoResurrected", SlashOptions, SlashCmds)
+    -- Set up our config options.
+    local profiles = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db)
 
-	local registry = LibStub("AceConfigRegistry-3.0")
-	registry:RegisterOptionsTable("IncognitoResurrected Options", Options)
-	registry:RegisterOptionsTable("IncognitoResurrected Profiles", profiles);
+    local config = LibStub("AceConfig-3.0")
+    config:RegisterOptionsTable("IncognitoResurrected", SlashOptions, SlashCmds)
 
-	local dialog = LibStub("AceConfigDialog-3.0");
-	self.optionFrames = {
-		main = dialog:AddToBlizOptions(	"IncognitoResurrected Options", "IncognitoResurrected"),
-		profiles = dialog:AddToBlizOptions(	"IncognitoResurrected Profiles", "Profiles", "IncognitoResurrected");
-	}
-	
-	-- Hook SendChatMessage function
-	self:RawHook("SendChatMessage", true)
-	
-	-- get current character name
-	character_name, _ = UnitName("player")
-	
-	self:Safe_Print(L["Loaded"])
+    local registry = LibStub("AceConfigRegistry-3.0")
+    registry:RegisterOptionsTable("IncognitoResurrected Options", Options)
+    registry:RegisterOptionsTable("IncognitoResurrected Profiles", profiles);
+
+    local dialog = LibStub("AceConfigDialog-3.0");
+    self.optionFrames = {
+        main = dialog:AddToBlizOptions("IncognitoResurrected Options",
+                                       "IncognitoResurrected"),
+        profiles = dialog:AddToBlizOptions("IncognitoResurrected Profiles",
+                                           "Profiles", "IncognitoResurrected")
+    }
+
+    -- Hook SendChatMessage function
+    self:RawHook("SendChatMessage", true)
+
+    -- get current character name
+    character_name, _ = UnitName("player")
+
+    self:Safe_Print(L["Loaded"])
 end
 
 --------------------------------
@@ -222,10 +222,14 @@ function IncognitoResurrected:SendChatMessage(msg, chatType, language, channel)
 					(self.db.profile.raid and chatType == "RAID") or 
 					(self.db.profile.party and chatType == "PARTY") or
 					(self.db.profile.instance_chat and chatType == "INSTANCE_CHAT")
-					(self.db.profile.world_chat and chatType == "WORLD_CHAT")
 				then
 					msg = "(" .. self.db.profile.name .. ") " .. msg
-
+					
+				-- Use World Chat Channels	
+				elseif self.db.profile.world_chat and chatType == "CHANNEL" then
+					msg = "(" .. self.db.profile.name .. ") " .. msg
+					
+				-- Use Specified Chat Channel, commas are not allowed	
 				elseif self.db.profile.channel and chatType == "CHANNEL" then
 					local id, chname = GetChannelName(channel)
 					if strupper(self.db.profile.channel) == strupper(chname) then
@@ -246,19 +250,17 @@ end
 ---------------------------
 
 function IncognitoResurrected:Safe_Print(msg)
-	if self.db.profile.debug then
-		self:Print(msg)
-	end
+    if self.db.profile.debug then self:Print(msg) end
 end
 
 function InterfaceOptionsFrame_OpenToCategory(IncognitoResurrected)
-	if type(IncognitoResurrected) == "string" then
-		return Settings.OpenToCategory(IncognitoResurrected);
-	elseif type(IncognitoResurrected) == "table" then
-		local frame = IncognitoResurrected;
-		local category = frame.name;
-		if category and type(category) == "string" then
-			return Settings.OpenToCategory(category);
-		end
-	end	
+    if type(IncognitoResurrected) == "string" then
+        return Settings.OpenToCategory(IncognitoResurrected);
+    elseif type(IncognitoResurrected) == "table" then
+        local frame = IncognitoResurrected;
+        local category = frame.name;
+        if category and type(category) == "string" then
+            return Settings.OpenToCategory(category);
+        end
+    end
 end

--- a/IncognitoResurrected.lua
+++ b/IncognitoResurrected.lua
@@ -1,7 +1,8 @@
 ------------------------
 ---		Version      ---
+---		 1.1.1       ---
 ------------------------
-// Version: 1.1.1
+
 
 ------------------------
 ---		Module       ---
@@ -93,20 +94,27 @@ local Options = {
 				name = L["instance_chat"],
 				desc = L["instance_chat_desc"],				
 				},
-			channel = {
+			world_chat = {
 				order = 6,
+				type = "toggle",
+				width = "full",
+				name = L["world_chat"],
+				desc = L["world_chat_desc"]
+			}
+			channel = {
+				order = 7,
 				type = "input",
 				name = L["channel"],
 				desc = L["channel_desc"],
 				},
 			channelinfo = {
-				order = 7, 
+				order = 8, 
 				type = "description",
 				name = "|cFFFFA500" .. L["channel_info_text"],
 				
 				},
 			debug = {
-				order = 8,
+				order = 9,
 				type = "toggle",
 				width = "full",
 				name = L["debug"],
@@ -214,6 +222,7 @@ function IncognitoResurrected:SendChatMessage(msg, chatType, language, channel)
 					(self.db.profile.raid and chatType == "RAID") or 
 					(self.db.profile.party and chatType == "PARTY") or
 					(self.db.profile.instance_chat and chatType == "INSTANCE_CHAT")
+					(self.db.profile.world_chat and chatType == "WORLD_CHAT")
 				then
 					msg = "(" .. self.db.profile.name .. ") " .. msg
 

--- a/IncognitoResurrected.toc
+++ b/IncognitoResurrected.toc
@@ -1,4 +1,4 @@
-## Interface: 110007
+## Interface: 110100
 ## Title: Incognito Resurrected
 ## Notes: Adds your name to chat messages
 
@@ -10,7 +10,7 @@
 ## X-Curse-Project-ID: 961634
 
 ## Interface-Classic: 11506
-## Interface-Cataclysm: 40401
+## Interface-Cataclysm: 40402
 
 #@no-lib-strip@
 embeds.xml

--- a/IncognitoResurrected.toc
+++ b/IncognitoResurrected.toc
@@ -3,7 +3,7 @@
 ## Notes: Adds your name to chat messages
 
 ## Author: info@starlynk.net, original author: daniel@pew.cc, nyyr
-## Version: 1.1
+## Version: 1.1.1
 ## SavedVariables: IncognitoResurrectedDB
 ## OptionalDeps: Ace3
 

--- a/IncognitoResurrected.toc
+++ b/IncognitoResurrected.toc
@@ -1,4 +1,4 @@
-## Interface: 110100
+## Interface: 110105
 ## Title: Incognito Resurrected
 ## Notes: Adds your name to chat messages
 

--- a/IncognitoResurrected_deDE.lua
+++ b/IncognitoResurrected_deDE.lua
@@ -29,7 +29,10 @@ L["instance_chat"] = "Instanz"
 L["instance_chat_desc"] = "Deinen Namen bei Instanznachrichten anzeigen, z.B. im Schlachtzugsbrowser und im Schlachtfeld (/i)."
 
 L["world_chat"] = "World Chat"
-L["world_chat_desc"] = "Add name to world chat messages, e.g., Say, LocalDefense, Trade, Services."
+L["world_chat_desc"] = "Add name to world chat messages, e.g., General, Trade, LocalDefense and Services.\n-- This is an all or none option, you cannot select which World Channel to enable/disable"
+
+L["world_chat_info"] = "World Chat"
+L["world_chat_info_desc"] = "Add name to world chat messages, e.g., General, Trade, LocalDefense and Services.\n-- This is an all or none option, you cannot select which World Channel to enable/disable"
 
 L["config"] = "Konfiguration"
 L["config_desc"] = "Konfigurationsdialog öffnen."

--- a/IncognitoResurrected_deDE.lua
+++ b/IncognitoResurrected_deDE.lua
@@ -1,3 +1,8 @@
+------------------------
+---		Version      ---
+---		 1.1.1       ---
+------------------------
+
 local L = LibStub("AceLocale-3.0"):NewLocale("IncognitoResurrected", "enUS", true)
 
 if not L then return end
@@ -23,6 +28,9 @@ L["raid_desc"] = "Deinen Namen bei Schlachtzugschatnachrichten anzeigen (/raid).
 L["instance_chat"] = "Instanz"
 L["instance_chat_desc"] = "Deinen Namen bei Instanznachrichten anzeigen, z.B. im Schlachtzugsbrowser und im Schlachtfeld (/i)."
 
+L["world_chat"] = "World Chat"
+L["world_chat_desc"] = "Add name to world chat messages, e.g., Say, LocalDefense, Trade, Services."
+
 L["config"] = "Konfiguration"
 L["config_desc"] = "Konfigurationsdialog öffnen."
 
@@ -35,4 +43,4 @@ L["channel_desc"] = "Deinen Namen in diesem benutzerdefinierten Kanal anzeigen."
 L["hideOnMatchingCharName"] = "Name nicht anzeigen, wenn er mit dem Charakternamen übereinstimmt"
 L["hideOnMatchingCharName_desc"] = "Wenn der oben angegebene Name gleich dem Namen deines aktuellen Charakters ist, fügt ihn IncognitoResurrected nicht hinzu, wenn diese Option ausgewählt ist."
 
-L["channel_info_text"] = "The 'Say' channel is not an acceptable option. This is a limitation within the Blizzard API"
+L["channel_info_text"] = "The World Channels are not an acceptable option.\n-- This is a limitation within the Blizzard API"

--- a/IncognitoResurrected_enUS.lua
+++ b/IncognitoResurrected_enUS.lua
@@ -35,4 +35,4 @@ L["channel_desc"] = "Add name to chat messages in this custom channel."
 L["hideOnMatchingCharName"] = "Hide name if it matches your character's name"
 L["hideOnMatchingCharName_desc"] = "If the name specified above matches your current character's name, IncognitoResurrected will not add it again if this option is checked."
 
-L["channel_info_text"] = "The 'Say' channel is not an acceptable option. This is a limitation within the Blizzard API"
+L["channel_info_text"] = "World channels (Say, General, Trade, Services) are not acceptable options.\nThis is a limitation within the Blizzard API."

--- a/IncognitoResurrected_enUS.lua
+++ b/IncognitoResurrected_enUS.lua
@@ -1,3 +1,8 @@
+------------------------
+---		Version      ---
+---		 1.1.1       ---
+------------------------
+
 local L = LibStub("AceLocale-3.0"):NewLocale("IncognitoResurrected", "enUS", true)
 
 if not L then return end
@@ -22,6 +27,9 @@ L["raid_desc"] = "Add name to raid chat messages (/raid)."
 
 L["instance_chat"] = "Instance"
 L["instance_chat_desc"] = "Add name to instance chat messages, e.g., LFR and battlegrounds (/i)."
+
+L["world_chat"] = "World Chat"
+L["world_chat_desc"] = "Add name to world chat messages, e.g., Say, LocalDefense, Trade, Services.\n-- This is an all or none option, you cannot select which World Channel to enable/disable"
 
 L["config"] = "Configuration"
 L["config_desc"] = "Open configuration window."

--- a/IncognitoResurrected_enUS.lua
+++ b/IncognitoResurrected_enUS.lua
@@ -29,7 +29,10 @@ L["instance_chat"] = "Instance"
 L["instance_chat_desc"] = "Add name to instance chat messages, e.g., LFR and battlegrounds (/i)."
 
 L["world_chat"] = "World Chat"
-L["world_chat_desc"] = "Add name to world chat messages, e.g., Say, LocalDefense, Trade, Services.\n-- This is an all or none option, you cannot select which World Channel to enable/disable"
+L["world_chat_desc"] = "Add name to world chat messages, e.g., General, Trade, LocalDefense and Services.\n-- This is an all or none option, you cannot select which World Channel to enable/disable"
+
+L["world_chat_info"] = "World Chat"
+L["world_chat_info_desc"] = "Add name to world chat messages, e.g., General, Trade, LocalDefense and Services.\n-- This is an all or none option, you cannot select which World Channel to enable/disable"
 
 L["config"] = "Configuration"
 L["config_desc"] = "Open configuration window."
@@ -38,7 +41,7 @@ L["debug"] = "Debug"
 L["debug_desc"] = "Enable debugging messages output. You probably don't want to enable this."
 
 L["channel"] = "Channel"
-L["channel_desc"] = "Add name to chat messages in this custom channel."
+L["channel_desc"] = "Add name to chat messages in this custom channel. Single Channel Only."
 
 L["hideOnMatchingCharName"] = "Hide name if it matches your character's name"
 L["hideOnMatchingCharName_desc"] = "If the name specified above matches your current character's name, IncognitoResurrected will not add it again if this option is checked."


### PR DESCRIPTION
Update to config options
- Added World Channels (General, Trade, LocalDefense and Services)
- Added description info to explain world channels are an all or nothing option. Cannot choose to disable individual world channels.
- Update to description text for custom channels. This field is for one channel, not multiple custom channels. Using commas does not work for additional custom channels.
(I am looking to update the code for comma-seperated channel names, no time frame though)

Updated TOC for Retail to 11.1.5