### PR TITLE
Midnight Updates

### DIFF
--- a/IncognitoResurrected.lua
+++ b/IncognitoResurrected.lua
@@ -1,4 +1,4 @@
---  Version: 1.6.0
+--  Version: 1.5.0
 IncognitoResurrected = LibStub("AceAddon-3.0"):NewAddon("IncognitoResurrected",
                                                         "AceConsole-3.0",
                                                         "AceEvent-3.0");
@@ -132,7 +132,7 @@ local Options = {
                     name = L["dungeon"],
                     desc = L["dungeon_desc"],
                     disabled = function()
-                        return IncognitoResurrected:IsRetailAPI()
+                        return IncognitoResurrected:IsModernRetail()
                     end
                 },
                 raid = {
@@ -142,7 +142,7 @@ local Options = {
                     name = L["raid"],
                     desc = L["raid_desc"],
                     disabled = function()
-                        return IncognitoResurrected:IsRetailAPI()
+                        return IncognitoResurrected:IsModernRetail()
                     end
                 },
                 battleground = {
@@ -152,7 +152,7 @@ local Options = {
                     name = L["battleground"],
                     desc = L["battleground_desc"],
                     disabled = function()
-                        return IncognitoResurrected:IsRetailAPI()
+                        return IncognitoResurrected:IsModernRetail()
                     end
                 },
                 arena = {
@@ -162,7 +162,10 @@ local Options = {
                     name = L["arena"],
                     desc = L["arena_desc"],
                     disabled = function()
-                        return IncognitoResurrected:IsRetailAPI()
+                        return IncognitoResurrected:IsModernRetail()
+                    end,
+                    hidden = function()
+                        return not IncognitoResurrected:HasArenas()
                     end
                 },
                 world_chat = {
@@ -428,6 +431,20 @@ end
 function IncognitoResurrected:IsRetailAPI()
     return type(C_ChatInfo) == "table" and type(C_ChatInfo.SendChatMessage) ==
                "function"
+end
+
+-- Returns true only on modern Retail (TWW 11.x / Midnight 12.x+) where
+-- SetText() taint in combat instances causes ADDON_ACTION_FORBIDDEN.
+-- MoP Classic (5.x) has C_ChatInfo but no taint restrictions.
+function IncognitoResurrected:IsModernRetail()
+    local _, _, _, tocVersion = GetBuildInfo()
+    return tocVersion and tocVersion >= 110000
+end
+
+-- Arenas were introduced in TBC (2.0).  Classic Era (1.x) has none.
+function IncognitoResurrected:HasArenas()
+    local _, _, _, tocVersion = GetBuildInfo()
+    return tocVersion and tocVersion >= 20000
 end
 ---------------------------------------------------------------------
 -- Slash Commands

--- a/IncognitoResurrected.toc
+++ b/IncognitoResurrected.toc
@@ -3,7 +3,7 @@
 ## Notes: Adds your name to chat messages
 
 ## Author: info@starlynk.net
-## Version: 1.6.0
+## Version: 1.5.0
 ## Category: Chat
 ## SavedVariables: IncognitoResurrectedDB
 ## OptionalDeps: Ace3

--- a/IncognitoResurrected_deDE.lua
+++ b/IncognitoResurrected_deDE.lua
@@ -1,4 +1,4 @@
--- Version 1.4.0
+-- Version 1.5.0
 local L = LibStub("AceLocale-3.0"):NewLocale("IncognitoResurrected", "enUS",
                                              true)
 

--- a/IncognitoResurrected_enUS.lua
+++ b/IncognitoResurrected_enUS.lua
@@ -1,4 +1,4 @@
--- Version 1.4.0
+-- Version 1.5.0
 local L = LibStub("AceLocale-3.0"):NewLocale("IncognitoResurrected", "enUS",
                                              true)
 

--- a/IncognitoResurrected_esES.lua
+++ b/IncognitoResurrected_esES.lua
@@ -1,4 +1,4 @@
--- Version 1.4.0
+-- Version 1.5.0
 local L = LibStub("AceLocale-3.0"):NewLocale("IncognitoResurrected", "esES",
                                              true)
 if not L then return end

--- a/IncognitoResurrected_ruRU.lua
+++ b/IncognitoResurrected_ruRU.lua
@@ -1,4 +1,4 @@
--- Version 1.4.0
+-- Version 1.5.0
 local L = LibStub("AceLocale-3.0"):NewLocale("IncognitoResurrected", "ruRU",
                                              true)
 

--- a/README.md
+++ b/README.md
@@ -1,51 +1,64 @@
-
 # Incognito Resurrected
+
 #### Incognito adds your specified name in front of your chat messages. Incongito Resurrrected can be enabled for guild (and officer), party and raid chat messages.
 
 ## Example
+
 <pre><code>[Guild] [Yourchar]: Some chat message </code></pre>
-becomes  
+
+becomes
+
 <pre><code>[Guild] [Yourchar]: (Yourname): Some chat message</code></pre>
 
-## Usage  
+## Usage
 
-**You can use the GUI config dialog or the slash commands /incognito or /inc
-slash options**  
+**You can use the GUI config dialog or the slash commands /incognito or /inc slash
+options**
+
 - /incognito config - Open configuration dialog
 - /incognito enable - Enable or disable adding your name to chat messages
 - /incognito name - The name that should be displayed in your chat messages
 
 ## AddOns Options
+
 - Enable - Enable adding your name to chat messages.
 - Name - The name that should be displayed in your chat messages
 - Guild - Add name to guild chat messages
 - Party - Add name to party chat messages
 - Raid - Add name to raid chat messages
-- LFR - Add name to LFR specific instance messsages
-    (Option disabled for Classic Era)
-- World - Add name to world chat messages, e.g., General, Trade, LocalDefense and Services  
-    (This is an all or none option, you cannot select which World Channel to enable/disable)
+- LFR - Add name to LFR specific instance messsages (Option disabled for Classic Era)
+- World - Add name to world chat messages, e.g., General, Trade, LocalDefense and
+  Services  
+   (This is an all or none option, you cannot select which World Channel to
+  enable/disable)
 - Channel - Add name to chat messages in a custom channel  
-    (Use comma-separation to add multiple channels)
+   (Use comma-separation to add multiple channels)
 - Community - Add name to chat messages in the Community channels.  
-    (Option disabled for Classic)
-- Debug - Enable debugging messages output. You probably don't want to enable this 
+   (Option disabled for Classic)
+- Debug - Enable debugging messages output. You probably don't want to enable this
 
 ## Known Issues
 
 ## Features and Bugs
-If you have a feature request of find a bug please report them through the Github repository:  
+
+If you have a feature request of find a bug please report them through the Github
+repository:  
 https://github.com/Starlynk1/IncognitoResurrected/issues
 
 ## Translations
+
 Translations are initially done using a translation website.  
 Please submit a ticket with updated translations if/when there is a better wording.  
-New languages are always appreciated. Please submit a ticket with those if you want to help.
+New languages are always appreciated. Please submit a ticket with those if you want to
+help.
 
 ## Credits
+
 Original Author: Nyyr  
 Resurrected Author: Starlynk  
 Collaborator: TheIceBadger  
-Contributors: Hubbotu  
-##  
-### Version: 1.4.0
+Contributors: Hubbotu
+
+##
+
+### Version: 1.5.0


### PR DESCRIPTION
**Midnight Updates:**
- Change on how the addon handles prefix injection.
No more use of rawhooks or securehooks
Ready for if/when Blizzard makes chat messages less restrictive for addons
- Retail only, the prefix's are not added to the outgoing chat messages
 This will now essentially disable Inc while in Combat Instances
 After outside of those instances, Inc will resume like normal
- Specific special characters will auto ignore.
 Not ignoring Curly braces so you can still use raid target icons in chat

**All Versions:**
- Polish pass for config screen.
- Update to slash commands
