### PR TITLE
Strip prefix from sent-message history

### DIFF
--- a/Libs/ChatCompat/ChatCompat.lua
+++ b/Libs/ChatCompat/ChatCompat.lua
@@ -174,6 +174,24 @@ function ChatCompat:HookChatEditBoxes(addon)
             if newText and newText ~= text then eb:SetText(newText) end
         end)
 
+        -- Strip prefix when the user browses sent-message history (Up/Down).
+        editBox:HookScript("OnKeyDown", function(eb, key)
+            if key ~= "UP" and key ~= "DOWN" then return end
+            if not addon._prefixEnabled then return end
+            if isModernRetail() and type(GetInstanceInfo) == "function" then
+                local _, instanceType = GetInstanceInfo()
+                if instanceType == "pvp" or instanceType == "arena" then
+                    return
+                end
+            end
+            local text = eb:GetText()
+            if not text or text == "" then return end
+            local prefix = addon:GetNamePrefix()
+            if text:sub(1, #prefix) == prefix then
+                eb:SetText(text:sub(#prefix + 1))
+            end
+        end)
+		
         editBox._chatCompatHooked = true
     end
 


### PR DESCRIPTION
When navigating Up or Down in history with how the new update edits the text in the edit box, history items will end up with the prefix, doing so results in multiple prefixes being added if you want to send one message several times, it also makes copy pasting your message include the prefix. 

This bit of code should strip that prefix out when looking up sent-message history, and only do so in the same situations as the send message functionality.

This makes the edit box behave more like it did before.